### PR TITLE
UI/fixing showpage mobilescreen size and updated map width accordingly.

### DIFF
--- a/public/stylesheets/app.css
+++ b/public/stylesheets/app.css
@@ -58,4 +58,4 @@ h1{
 #newcamp{
     background-color: black;
     color: white;
-}
+}  

--- a/public/stylesheets/app.css
+++ b/public/stylesheets/app.css
@@ -59,3 +59,26 @@ h1{
     background-color: black;
     color: white;
 }  
+
+@media (max-width: 768px) {
+    #map {
+        width: 100%;
+        height: auto;
+        min-height: 300px; /* Set a minimum height for mobile */
+    }
+
+    #showinfo {
+        display: flex;
+        flex-direction: column; 
+        align-items: center;    
+    }
+
+    .col-6 {
+        width: 100%;
+        height: auto;
+    }
+
+    .row {
+        flex-direction: column !important;
+    }
+}

--- a/public/stylesheets/app.css
+++ b/public/stylesheets/app.css
@@ -59,26 +59,3 @@ h1{
     background-color: black;
     color: white;
 }  
-
-@media (max-width: 768px) {
-    #map {
-        width: 100%;
-        height: auto;
-        min-height: 300px; /* Set a minimum height for mobile */
-    }
-
-    #showinfo {
-        display: flex;
-        flex-direction: column; 
-        align-items: center;    
-    }
-
-    .col-6 {
-        width: 100%;
-        height: auto;
-    }
-
-    .row {
-        flex-direction: column !important;
-    }
-}

--- a/views/campgrounds/show.ejs
+++ b/views/campgrounds/show.ejs
@@ -1,8 +1,8 @@
 <%layout('layouts/boilerplate')%>
     <link rel="stylesheet" href="/stylesheets/stars.css">
 
-    <div class="row flex-column flex-md-row" id="showinfo">
-        <div class="col-12 col-md-6 mb-3">
+    <div class="row" id="showinfo">
+        <div class="col-md-6">
             <div id="campgroundCarousel" class="carousel slide">
                 <div class="carousel-inner">
                     <% campground.images.forEach((img,i)=>  {%>
@@ -53,7 +53,7 @@
                         </div>
             </div>
         </div>
-        <div class="col-6 text-white">
+        <div class="col-md-6 text-white">
             <div id="map"></div>
             <% if(currentUser){ %>
                 <h2>Leave a Review</h2>

--- a/views/campgrounds/show.ejs
+++ b/views/campgrounds/show.ejs
@@ -1,8 +1,8 @@
 <%layout('layouts/boilerplate')%>
     <link rel="stylesheet" href="/stylesheets/stars.css">
 
-    <div class="row" id="showinfo">
-        <div class="col-6">
+    <div class="row flex-column flex-md-row" id="showinfo">
+        <div class="col-12 col-md-6 mb-3">
             <div id="campgroundCarousel" class="carousel slide">
                 <div class="carousel-inner">
                     <% campground.images.forEach((img,i)=>  {%>

--- a/views/campgrounds/show.ejs
+++ b/views/campgrounds/show.ejs
@@ -116,4 +116,4 @@
     const campground=<%-JSON.stringify(campground)%>;
 </script>
 
-<script src="/javascripts/showPageMap.js"></script>
+<script src="/javascripts/showPageMap.js"></script>   


### PR DESCRIPTION
📋 Description
This Pull Request ensures that the user can view the images clearly and in bigger height and width on moblie screen size.
Earlier the images their description and map was viewed column-wise which was not completing the usage of images completely.

🔨 Changes Made
Made the components view row-wise
Fixed the map width for mobile screen size through CSS media-queries
✅ Checklist
Before submitting the PR, please make sure you have completed the following:

[✅] My code follows the style guidelines of this project.
[✅] I have performed a self-review of my own code.
[✅] I have commented my code, particularly in hard-to-understand areas.
 I have made corresponding changes to the documentation (if applicable).
[✅] My changes generate no new warnings.
[✅] I have tested it locally and it works fine.
 Any dependent changes have been merged and published in downstream modules.
🏷️ Types of Changes
What type of changes does your code introduce? (Check all that apply)

 Bug fix (non-breaking change which fixes an issue) 🐛
 New feature (non-breaking change which adds functionality) ✨
[✅] UI enhancement (non-breaking change which enhances UI) 🎨
 Documentation update 📚


🤝 Related Issues
Fixes [UI ENHANCEMENT] make changes in the show page for mobile screen size. #65

Kindly review my changes.
Please tell me if it produces any errors.
Thankyou.

