### PR TITLE
 Display Price on Individual Campground Listing Pages (#382)

### DIFF
--- a/views/campgrounds/show.ejs
+++ b/views/campgrounds/show.ejs
@@ -30,6 +30,9 @@
                     <p class="card-text description">
                         <%= campground.description %>
                     </p>
+                    <p class="card-text">
+                        <%= campground.price %>
+                    </p>
                 </div>
 
                 <p class="" id="showlocation">

--- a/views/campgrounds/show.ejs
+++ b/views/campgrounds/show.ejs
@@ -31,7 +31,7 @@
                         <%= campground.description %>
                     </p>
                     <p class="card-text">
-                        <%= campground.price %>
+                        &#8377; <%= campground.price %>
                     </p>
                 </div>
 


### PR DESCRIPTION
## 📋 Description

This PR addresses issue #382 by adding a visible price section on individual campground listing pages. Previously, the lack of price visibility on these pages led to user confusion, as they couldn't find pricing details when viewing a specific campground. 

## 🔨 Changes Made

Added a dedicated section for displaying the price on individual campground listing pages.
- 
- 
- 

## ✅ Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings.
- [x] I have tested it locally and it works fine.
- [x] Any dependent changes have been merged and published in downstream modules.

## 🏷️ Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue) 🐛
- [x] New feature (non-breaking change which adds functionality) ✨
- [ ] UI enhancement (non-breaking change which enhances UI) 🎨
- [ ] Documentation update 📚

## 🤝 Related Issues
 Fixes #382

